### PR TITLE
Deploy on Google Cloud run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM frolvlad/alpine-miniconda3:python3.7
 
 EXPOSE 5000
+EXPOSE 8080
 
 # Set the working directory to /malaria_hero
 WORKDIR /malaria_hero
@@ -14,4 +15,6 @@ RUN conda env update --name base --file environment.yml \
 ADD . /malaria_hero/
 
 WORKDIR /malaria_hero/src/
+
+ENTRYPOINT ["gunicorn", "--bind", ":8080", "dash_app:server", "--timeout", "180"]
 

--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,10 @@ browse_files:
 destroy:
 
 	docker rmi $$(docker images -qf "reference=malaria*")
+
+deploy_gcp:
+
+	docker build -f Dockerfile -t gcr.io/malaria-hero/mh_api:0 .
+	docker push gcr.io/malaria-hero/mh_api:0
+	gcloud run deploy malaria-hero --image=gcr.io/malaria-hero/mh_api:0 --platform=managed --region=us-west1 ;\
+	--timeout=60 --concurrency=5 --cpu=2 --memory=1024Mi --max-instances=4 --allow-unauthenticated 

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,15 @@ dependencies:
      - python=3.7
      - pip
      - ipykernel
-     - pandas
-     - scipy
-     - dash
+     - pandas=1.2.0
+     - scipy=1.5.2
+     - dash=1.18.1
      - pillow=8.0.1
      - gunicorn
      - eventlet
      - pip:
         - tensorflow==2.0.1
+        - werkzeug==2.0.0
+        - protobuf==3.20.1 
+        - flask==2.0.3
+        - jinja2==3.0.1


### PR DESCRIPTION
Locks versions and adds dependency to resolve issues 

Moving to Google Cloud Run: Modifies the dockerfile to make the dashboard run with gunicorn. Docker swarm (nginx and malaria hero docker images) cannot be initialize through docker compose because we cannot ssh into Cloud Run. https://stackoverflow.com/questions/63782456/docker-compose-yml-in-google-cloud-run. 